### PR TITLE
handle nested queries more consistent when being nested more than once

### DIFF
--- a/src/main/java/com/github/raymanrt/orientqb/query/Target.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/Target.java
@@ -27,7 +27,10 @@ public class Target {
     private final String target;
 
     public Target(String target) {
-        if (target.indexOf('-') != -1){
+        int indexOf = target.indexOf('-');
+        boolean betweenQuotes = target.indexOf('\'') < indexOf && target.indexOf('\'', indexOf) > indexOf;
+        boolean betweenApostrophes = target.indexOf('`') < indexOf && target.indexOf('`', indexOf) > indexOf;
+        if (indexOf != -1 && !(betweenQuotes || betweenApostrophes)) {
             this.target = "`" + target + "`";
         } else {
             this.target = target;
@@ -38,7 +41,7 @@ public class Target {
         return new Target(target);
     }
 
-    public static Target target(String ... targets) {
+    public static Target target(String... targets) {
         return new Target(Commons.arrayToString(targets));
     }
 


### PR DESCRIPTION
When an edge was defined with a '-' sign in it, the nesting of that name causes the query to be constructed in such a way that orientdb threw an exception because of an invalid query.