### PR TITLE
Updates for Fetchplan/toJSON

### DIFF
--- a/src/main/java/com/github/raymanrt/orientqb/query/FetchingStrategy.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/FetchingStrategy.java
@@ -19,10 +19,12 @@ package com.github.raymanrt.orientqb.query;
 import com.github.raymanrt.orientqb.query.projection.AtomicProjection;
 
 public class FetchingStrategy {
+    public static Projection ALL_LEVELS = Projection.projection("[*]");
     public static int ONLY_CURRENT = 0;
     public static int UNLIMITED = -1;
     public static int EXCLUDE_CURRENT = -2;
 
+    private Projection levels;
     private Projection fieldPath;
     private int depthLevel;
 
@@ -36,7 +38,34 @@ public class FetchingStrategy {
         this.depthLevel = depthLevel;
     }
 
+    public FetchingStrategy(Projection levels, Projection fieldPath, int depthLevel) {
+        this.levels = levels;
+        this.fieldPath = fieldPath;
+        this.depthLevel = depthLevel;
+    }
+
+    public FetchingStrategy(Projection levels, String fieldName, int depthLevel) {
+        this.levels = levels;
+        this.fieldPath = new AtomicProjection(fieldName);
+        this.depthLevel = depthLevel;
+    }
+
+    public FetchingStrategy(String levelsName, Projection fieldPath, int depthLevel) {
+        this.levels = new AtomicProjection(levelsName);
+        this.fieldPath = fieldPath;
+        this.depthLevel = depthLevel;
+    }
+
+    public FetchingStrategy(String levelsName, String fieldName, int depthLevel) {
+        this.levels = new AtomicProjection(levelsName);
+        this.fieldPath = new AtomicProjection(fieldName);
+        this.depthLevel = depthLevel;
+    }
+
     public String toString() {
+        if (levels != null) {
+            return levels.toString() + fieldPath.toString() + ":" + Integer.toString(depthLevel);
+        }
         return fieldPath.toString() + ":" + Integer.toString(depthLevel);
     }
 

--- a/src/main/java/com/github/raymanrt/orientqb/query/Projection.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/Projection.java
@@ -35,7 +35,7 @@ import static com.github.raymanrt.orientqb.util.Commons.cast;
 import static com.github.raymanrt.orientqb.util.Commons.singleQuote;
 import static com.github.raymanrt.orientqb.util.Commons.singleQuoteFunction;
 import static com.github.raymanrt.orientqb.util.Joiner.listJoiner;
-import static com.github.raymanrt.orientqb.util.Joiner.commaJoiner;
+import static com.github.raymanrt.orientqb.util.Joiner.oneCommaJoiner;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.transform;
 
@@ -327,7 +327,7 @@ public abstract class Projection implements Assignable {
 	}
 
 	public Projection toJson(Projection... projections) {
-		return new CompositeProjection("%s.toJson('%s')", this, projection(commaJoiner.join(projections)));
+		return new CompositeProjection("%s.toJson('%s')", this, projection(oneCommaJoiner.join(projections)));
 	}
 
 	public Projection toLowerCase() {

--- a/src/main/java/com/github/raymanrt/orientqb/query/Projection.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/Projection.java
@@ -35,6 +35,7 @@ import static com.github.raymanrt.orientqb.util.Commons.cast;
 import static com.github.raymanrt.orientqb.util.Commons.singleQuote;
 import static com.github.raymanrt.orientqb.util.Commons.singleQuoteFunction;
 import static com.github.raymanrt.orientqb.util.Joiner.listJoiner;
+import static com.github.raymanrt.orientqb.util.Joiner.commaJoiner;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.transform;
 
@@ -322,7 +323,11 @@ public abstract class Projection implements Assignable {
 	}
 
 	public Projection toJson(String format) {
-		throw new UnsupportedOperationException("not implemented yet");
+		return new CompositeProjection("%s.toJson('%s')", this, new AtomicProjection(format));
+	}
+
+	public Projection toJson(Projection... projections) {
+		return new CompositeProjection("%s.toJson('%s')", this, projection(commaJoiner.join(projections)));
 	}
 
 	public Projection toLowerCase() {

--- a/src/main/java/com/github/raymanrt/orientqb/query/ProjectionFunction.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/ProjectionFunction.java
@@ -264,6 +264,11 @@ public class ProjectionFunction {
 		return new CompositeProjection("unionAll(%s)", Projection.projection(projectionsString));
 	}
 
+	public static Projection fetchPlan(FetchingStrategy... strategies) {
+		String projectionsString = Joiner.oneSpaceJoiner.join(strategies);
+		return new CompositeProjection("fetchPlan:%s", Projection.projection(projectionsString));
+	}
+
 	//// SPECIAL ////
 
 	public static Projection nested(Query query) {

--- a/src/main/java/com/github/raymanrt/orientqb/query/Query.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/Query.java
@@ -150,8 +150,10 @@ public class Query implements Assignable {
 		return this;
 	}
 
-	public Query fetchPlan(FetchingStrategy strategy) {
-		fetchPlan.add(strategy.toString());
+	public Query fetchPlan(FetchingStrategy... strategies) {
+		for(Strategy strategy : strategies) {
+			fetchPlan.add(strategy.toString());
+		}
 		return this;
 	}
 
@@ -317,7 +319,7 @@ public class Query implements Assignable {
 
 	private String generateFetchPlan() {
 		if(fetchPlan.size() > 0) {
-			String fetchPlanString = Joiner.listJoiner.join(fetchPlan);
+			String fetchPlanString = Joiner.oneSpaceJoiner.join(fetchPlan);
 			return " " + FETCHPLAN + " " + fetchPlanString + " ";
 		}
 		return "";

--- a/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
+++ b/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
@@ -19,6 +19,7 @@ package com.github.raymanrt.orientqb.util;
 public class Joiner {
 
     public final static com.google.common.base.Joiner listJoiner = com.google.common.base.Joiner.on(", ");
+    public final static com.google.common.base.Joiner commaJoiner = com.google.common.base.Joiner.on(",");
     public final static com.google.common.base.Joiner oneSpaceJoiner = com.google.common.base.Joiner.on(" ");
     public final static com.google.common.base.Joiner andJoiner = com.google.common.base.Joiner.on(" " + Token.AND + " ");
     public final static com.google.common.base.Joiner orJoiner = com.google.common.base.Joiner.on(" " + Token.OR + " ");

--- a/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
+++ b/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
@@ -19,7 +19,7 @@ package com.github.raymanrt.orientqb.util;
 public class Joiner {
 
     public final static com.google.common.base.Joiner listJoiner = com.google.common.base.Joiner.on(", ");
-//    public final static com.google.common.base.Joiner oneSpaceJoiner = com.google.common.base.Joiner.on(" ");
+    public final static com.google.common.base.Joiner oneSpaceJoiner = com.google.common.base.Joiner.on(" ");
     public final static com.google.common.base.Joiner andJoiner = com.google.common.base.Joiner.on(" " + Token.AND + " ");
     public final static com.google.common.base.Joiner orJoiner = com.google.common.base.Joiner.on(" " + Token.OR + " ");
 

--- a/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
+++ b/src/main/java/com/github/raymanrt/orientqb/util/Joiner.java
@@ -19,7 +19,7 @@ package com.github.raymanrt.orientqb.util;
 public class Joiner {
 
     public final static com.google.common.base.Joiner listJoiner = com.google.common.base.Joiner.on(", ");
-    public final static com.google.common.base.Joiner commaJoiner = com.google.common.base.Joiner.on(",");
+    public final static com.google.common.base.Joiner oneCommaJoiner = com.google.common.base.Joiner.on(",");
     public final static com.google.common.base.Joiner oneSpaceJoiner = com.google.common.base.Joiner.on(" ");
     public final static com.google.common.base.Joiner andJoiner = com.google.common.base.Joiner.on(" " + Token.AND + " ");
     public final static com.google.common.base.Joiner orJoiner = com.google.common.base.Joiner.on(" " + Token.OR + " ");

--- a/src/test/java/com/github/raymanrt/orientqb/query/ProjectionFunctionTest.java
+++ b/src/test/java/com/github/raymanrt/orientqb/query/ProjectionFunctionTest.java
@@ -438,6 +438,12 @@ public class ProjectionFunctionTest {
 	}
 
 	@Test
+	public void fetchPlanTest() {
+		Projection p = fetchPlan(new FetchingStrategy("child",FetchingStrategy.UNLIMITED), new FetchingStrategy("parent",FetchingStrategy.EXCLUDE_CURRENT));
+		assertEquals("fetchPlan:child:-1 parent:-2", p.toString());
+	}
+
+	@Test
 	public void nestedTest() {
 
 		Query innerQuery = new Query()

--- a/src/test/java/com/github/raymanrt/orientqb/query/ProjectionMethodTest.java
+++ b/src/test/java/com/github/raymanrt/orientqb/query/ProjectionMethodTest.java
@@ -466,11 +466,11 @@ public class ProjectionMethodTest {
 		Projection p = projection(simpleField).toJson();
 		assertEquals("field.toJson()", p.toString());
 
-		try {
-			projection(simpleField).toJson("format");
-		} catch (UnsupportedOperationException ex) {
-			assertEquals("not implemented yet", ex.getMessage());
-		}
+		p = projection(simpleField).toJson("type");
+		assertEquals("field.toJson('type')", p.toString());
+
+		p = projection(simpleField).toJson(projection("version"), projection("rid"));
+		assertEquals("field.toJson('version,rid')", p.toString());
 	}
 
 	@Test

--- a/src/test/java/com/github/raymanrt/orientqb/query/QueryTest.java
+++ b/src/test/java/com/github/raymanrt/orientqb/query/QueryTest.java
@@ -157,29 +157,27 @@ public class QueryTest {
 		Query q = new Query()
 				.select("field")
 				.from("V")
-				.fetchPlan(new FetchingStrategy(ALL, FetchingStrategy.UNLIMITED));
-		assertEquals("SELECT field FROM V FETCHPLAN *:-1", q.toString());
+				.fetchPlan(new FetchingStrategy(FetchingStrategy.ALL_LEVELS, ALL, FetchingStrategy.UNLIMITED));
+		assertEquals("SELECT field FROM V FETCHPLAN [*]*:-1", q.toString());
 
 		q = new Query()
 				.select("field")
 				.from("V")
 				.fetchPlan(new FetchingStrategy(ALL, FetchingStrategy.UNLIMITED))
-				.fetchPlan(new FetchingStrategy("field", FetchingStrategy.EXCLUDE_CURRENT));
-		assertEquals("SELECT field FROM V FETCHPLAN *:-1, field:-2", q.toString());
+                .fetchPlan(new FetchingStrategy("[1]","field", FetchingStrategy.EXCLUDE_CURRENT));
+		assertEquals("SELECT field FROM V FETCHPLAN *:-1 [1]field:-2", q.toString());
 
 		q = new Query()
 				.select("field")
 				.from("V")
-				.fetchPlan(new FetchingStrategy(ALL, FetchingStrategy.UNLIMITED))
-				.fetchPlan(new FetchingStrategy("field", FetchingStrategy.EXCLUDE_CURRENT))
-				.fetchPlan(new FetchingStrategy("field", FetchingStrategy.EXCLUDE_CURRENT));
-		assertEquals("SELECT field FROM V FETCHPLAN *:-1, field:-2", q.toString());
+				.fetchPlan(new FetchingStrategy(ALL, FetchingStrategy.UNLIMITED), new FetchingStrategy("field", FetchingStrategy.EXCLUDE_CURRENT), new FetchingStrategy("field", FetchingStrategy.EXCLUDE_CURRENT));
+		assertEquals("SELECT field FROM V FETCHPLAN *:-1 field:-2", q.toString());
 
 		q = new Query()
 				.select("field")
 				.from("V")
-				.fetchPlan(new FetchingStrategy(projection("field").dot(projection("name")), 10));
-		assertEquals("SELECT field FROM V FETCHPLAN field.name:10", q.toString());
+				.fetchPlan(new FetchingStrategy("[-5]",projection("field").dot(projection("name")), 10));
+		assertEquals("SELECT field FROM V FETCHPLAN [-5]field.name:10", q.toString());
 	}
 
 	@Test


### PR DESCRIPTION
Ran into a few snags while working with fetchplan and toJson method.

The toJson method was not implemented yet but since I needed to use it I implemented as described by the OrientDB manul.

How fetchplans really works remains still a mystery to me but these changes should make it compliant to the OrientDB manual. Also used my fork in my project and running with the 2.10 version of the database seems to work as intended.