### PR TITLE
Change AbstractQuery to make it more suitable for UPDATE and common introspection

### DIFF
--- a/src/main/java/com/github/raymanrt/orientqb/query/Query.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/Query.java
@@ -87,12 +87,12 @@ public class Query extends AbstractQuery implements Assignable {
 	}
 
 	public Query from(Target target) {
-		super.from(target);
+		super.setTarget(target);
 		return this;
 	}
 
 	public Query from(String target) {
-		super.from(target);
+		super.setTarget(target);
 		return this;
 	}
 

--- a/src/main/java/com/github/raymanrt/orientqb/query/core/AbstractQuery.java
+++ b/src/main/java/com/github/raymanrt/orientqb/query/core/AbstractQuery.java
@@ -52,7 +52,7 @@ public abstract class AbstractQuery {
     private Optional<Long> timeoutInMS = Optional.absent();
     private Optional<TimeoutStrategy> timeoutStrategy = Optional.absent();
 
-    protected Target getTarget() {
+    public Target getTarget() {
         return target;
     }
 
@@ -61,17 +61,17 @@ public abstract class AbstractQuery {
         return this;
     }
 
-    protected AbstractQuery from(Target target) {
+    public AbstractQuery setTarget(Target target) {
         this.target = target;
         return this;
     }
 
-    protected AbstractQuery from(String target) {
+    public AbstractQuery setTarget(String target) {
         this.target = target(target);
         return this;
     }
 
-    protected AbstractQuery where(Clause clause) {
+    public AbstractQuery where(Clause clause) {
         if(!clause.isEmpty()) {
             clauses.add(clause);
         }
@@ -98,7 +98,7 @@ public abstract class AbstractQuery {
         return this;
     }
 
-    protected String joinWhere() {
+    public String joinWhere() {
         if(clauses.size() == 1) {
             String flattenWhere = Joiner.andJoiner.join(clauses);
             return " " + WHERE + " " + flattenWhere + " ";

--- a/src/main/java/com/gitub/raymanrt/orientqb/delete/Delete.java
+++ b/src/main/java/com/gitub/raymanrt/orientqb/delete/Delete.java
@@ -43,12 +43,12 @@ public class Delete extends AbstractQuery {
     }
 
     public Delete from(Target target) {
-        super.from(target);
+        super.setTarget(target);
         return this;
     }
 
     public Delete from(String target) {
-        super.from(target);
+        super.setTarget(target);
         return this;
     }
 


### PR DESCRIPTION
There are 2 reasons for those changes:

1) "FROM" makes sense only for SELECT and DELETE, but to be suitable for UPDATE or INSERT it's better to use "target" on AbstractQuery level
2) In code of [Orienteer](http://orienteer.org/) we have some abstraction which can add additional "where"  clauses disregard fact that it's SELECT or DELETE and we have to duplicate almost the same code for every type of query. So changes making code be suitable for "highlevel abstraction/introspection".

Hope that you agree! Thank you for this great library!